### PR TITLE
ioloop: Fix hanging outgoing TCP connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 *.log
 .state
+*.swo
+*.swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (${CMAKE_CXX_COMPILER_VERSION} VE
      zeek_plugin_link_library(stdc++fs)
 endif()
 
-zeek_plugin_cc(src/Plugin.cc src/Nodejs.cc)
+zeek_plugin_cc(src/Plugin.cc src/Nodejs.cc src/IOLoop.cc)
 zeek_plugin_bif(src/zeekjs.bif)
 zeek_plugin_dist_files(README CHANGES COPYING VERSION)
 zeek_plugin_end()

--- a/dev/nodejs.lsan.supp
+++ b/dev/nodejs.lsan.supp
@@ -5,10 +5,11 @@ leak:PlatformWorkerThread
 leak:node::native_module::NativeModuleEnv::CompileFunction
 leak:v8::internal::GeneratedCode
 leak:v8::internal::Heap::GenerationalBarrierSlow
+leak:v8::internal::Heap::InsertIntoRememberedSetFromCode
 leak:v8::internal::Heap::PerformGarbageCollection
 leak:v8::internal::Object::SetDataProperty
 leak:v8::internal::OptimizedCompilationJob::FinalizeJob
 leak:v8::internal::Runtime_RegExpExec
 leak:v8::internal::TorqueGeneratedInterceptorInfo
 leak:v8::internal::UnoptimizedCompilationJob::FinalizeJob
-leak:v8::internal::Heap::InsertIntoRememberedSetFromCode
+leak:v8::internal::baseline::BaselineBatchCompiler::CompileBatch

--- a/src/IOLoop.cc
+++ b/src/IOLoop.cc
@@ -1,0 +1,64 @@
+#include <stdexcept>
+
+// pipe2, O_CLOEXEC, ...
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "IOLoop.h"
+#include "Nodejs.h"
+
+namespace plugin::Corelight_ZeekJS::IOLoop {
+
+void LoopSource::Process() {
+  instance_->Process();
+}
+
+double LoopSource::GetNextTimeout() {
+  return instance_->GetNextTimeout();
+}
+
+void LoopSource::UpdateTime() {
+  instance_->UpdateTime();
+}
+
+int LoopSource::GetFd() {
+  return instance_->GetLoopFd();
+}
+
+PipeSource::PipeSource(plugin::Nodejs::Instance* instance) : instance_(instance) {
+  if (pipe2(notify_pipe_.data(), O_CLOEXEC | O_NONBLOCK)) {
+    throw std::runtime_error("Failed to create notify_pipe");
+  }
+  SetClosed(false);
+}
+
+PipeSource::~PipeSource() {
+  if (close(notify_pipe_[0]) != 0)
+    eprintf("Failed to close _notify_pipe[0]");
+  if (close(notify_pipe_[1]) != 0)
+    eprintf("Failed to close _notify_pipe[0]");
+}
+
+void PipeSource::Process() {
+  char c;
+  ssize_t r;
+  if ((r = read(notify_pipe_[0], &c, 1)) != 1) {
+    eprintf("r=%zd error=%s", r, strerror(errno));
+    throw std::runtime_error("Failed to read notification");
+  }
+  instance_->Process();
+}
+
+int PipeSource::GetFd() {
+  return notify_pipe_[0];
+}
+
+void PipeSource::Notify() {
+  ssize_t r;
+  if ((r = write(notify_pipe_[1], "n", 1) != 1)) {
+    eprintf("r=%zd error=%s", r, strerror(errno));
+    throw std::runtime_error("Failed to send notification");
+  }
+}
+
+}  // namespace plugin::Corelight_ZeekJS::IOLoop

--- a/src/IOLoop.h
+++ b/src/IOLoop.h
@@ -1,0 +1,60 @@
+#pragma once
+#include <array>
+#include <stdexcept>
+
+#include <zeek/iosource/IOSource.h>
+
+namespace plugin::Nodejs {
+class Instance;
+}
+
+namespace plugin::Corelight_ZeekJS::IOLoop {
+
+/*
+ * Tiny layer between Nodejs::Instance and the zeek::iosource::IOSource
+ * world. Not sure how useful really, but at least it disconnects lifetime
+ * of the Node.js instance and the IOSource as the IOManager deletes the
+ * IOSources registered with it.
+ */
+class LoopSource : public zeek::iosource::IOSource {
+ public:
+  LoopSource(plugin::Nodejs::Instance* instance) : instance_(instance) {
+    SetClosed(false);
+  }
+
+  void Process() override;
+
+  double GetNextTimeout() override;
+
+  const char* Tag() override { return "LoopSource"; };
+
+  void UpdateTime();
+
+  int GetFd();
+
+ private:
+  plugin::Nodejs::Instance* instance_ = nullptr;
+};
+
+// IOSource build around pipe() for kicking the Zeek IO loop
+class PipeSource : public zeek::iosource::IOSource {
+ public:
+  PipeSource(plugin::Nodejs::Instance* instance);
+  ~PipeSource() override;
+
+  void Process() override;
+
+  double GetNextTimeout() override { return -1.0; };
+
+  const char* Tag() override { return "PipeSource"; }
+
+  int GetFd();
+
+  void Notify();
+
+ private:
+  plugin::Nodejs::Instance* instance_ = nullptr;
+  std::array<int, 2> notify_pipe_;
+};
+
+}  // namespace plugin::Corelight_ZeekJS::IOLoop

--- a/src/Nodejs.h
+++ b/src/Nodejs.h
@@ -6,6 +6,7 @@
 #include <node/v8.h>
 #include <uv.h>
 
+#include "IOLoop.h"
 #include "ZeekJS.h"
 
 // Prototypes for plugin hooks.
@@ -85,12 +86,15 @@ class Instance {
 
   void Done();
 
+  void SetZeekNotifier(plugin::Corelight_ZeekJS::IOLoop::PipeSource* n) {
+    zeek_notifier_ = n;
+  }
+
   // Called by the thin JsLoopIOSource
   int GetLoopFd();
   void Process();
   void UpdateTime();
   double GetNextTimeout();
-  const char* Tag() { return "NodejsLoop"; }
 
   //
   // Invoked from Javascript to register the given function as
@@ -150,6 +154,9 @@ class Instance {
 
   // Wrapping.
   std::unique_ptr<ZeekValWrapper> zeek_val_wrapper_;
+
+  // Allows kicking/notifying the Zeek IO loop.
+  plugin::Corelight_ZeekJS::IOLoop::PipeSource* zeek_notifier_;
 };
 
 class EventHandler : public plugin::Corelight_ZeekJS::Js::EventHandler {

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -9,37 +9,11 @@
 #include <zeek/iosource/IOSource.h>
 #include <zeek/plugin/Plugin.h>
 
+#include "IOLoop.h"
 #include "Nodejs.h"
 #include "ZeekJS.h"
 
 namespace plugin::Corelight_ZeekJS {
-
-/*
- * Tiny layer between Nodejs::Instance and the zeek::iosource::IOSource
- * world. Not sure how useful really, but at least it disconnects lifetime
- * of the Node.js instance and the IOSource as the IOManager deletes the
- * IOSources registered with it.
- */
-class JsLoopIOSource : public zeek::iosource::IOSource {
- public:
-  JsLoopIOSource(plugin::Nodejs::Instance* instance) : instance_(instance) {
-    SetClosed(false);
-  }
-
-  void Process() override { instance_->Process(); }
-
-  double GetNextTimeout() override {
-    // std::fprintf(stderr, "GetNextTimeout\n");
-    return instance_->GetNextTimeout();
-  }
-
-  const char* Tag() override { return instance_->Tag(); }
-
-  void UpdateTime() { instance_->UpdateTime(); }
-
- private:
-  plugin::Nodejs::Instance* instance_ = nullptr;
-};
 
 class Plugin : public zeek::plugin::Plugin {
  public:
@@ -84,7 +58,6 @@ class Plugin : public zeek::plugin::Plugin {
 
   std::vector<std::filesystem::path> load_files;
   plugin::Nodejs::Instance nodejs;
-  JsLoopIOSource* loop_io_source;
 };
 
 extern Plugin plugin;

--- a/src/ZeekJS.h
+++ b/src/ZeekJS.h
@@ -1,4 +1,9 @@
 #pragma once
+#include <chrono>
+using std::chrono::duration_cast;
+using std::chrono::microseconds;
+using std::chrono::seconds;
+using std::chrono::system_clock;
 
 #include <zeek/Event.h>
 #include <zeek/Stmt.h>
@@ -26,22 +31,24 @@ class HookHandler {
 };
 
 /* Poor man's logging */
-#define eprintf(...)                        \
-  do {                                      \
-    std::fprintf(stderr, "[ ERROR ] ");     \
-    std::fprintf(stderr, "%s: ", __func__); \
-    std::fprintf(stderr, __VA_ARGS__);      \
-    std::fprintf(stderr, "\n");             \
+#define eprintf(...)                                        \
+  do {                                                      \
+    auto __now = system_clock::now().time_since_epoch();    \
+    auto __us = duration_cast<microseconds>(__now).count(); \
+    std::fprintf(stderr, "[ ERROR ] %s: ", __func__);       \
+    std::fprintf(stderr, __VA_ARGS__);                      \
+    std::fprintf(stderr, "\n");                             \
   } while (0);
 
 // #define DEBUG 1
 #ifdef DEBUG
-#define dprintf(...)                        \
-  do {                                      \
-    std::fprintf(stderr, "[ DEBUG ] ");     \
-    std::fprintf(stderr, "%s: ", __func__); \
-    std::fprintf(stderr, __VA_ARGS__);      \
-    std::fprintf(stderr, "\n");             \
+#define dprintf(...)                                                       \
+  do {                                                                     \
+    auto __now = system_clock::now().time_since_epoch();                   \
+    auto __us = duration_cast<microseconds>(__now).count();                \
+    std::fprintf(stderr, "%lf [ DEBUG ] %s ", __us / 1000000.0, __func__); \
+    std::fprintf(stderr, __VA_ARGS__);                                     \
+    std::fprintf(stderr, "\n");                                            \
   } while (0);
 #else
 #define dprintf(...) \

--- a/tests/zeekjs/integration/http.sh
+++ b/tests/zeekjs/integration/http.sh
@@ -1,0 +1,64 @@
+# @TEST-DOC: Run a http server and client using two separate zeek processes. Expect 100 requests to take less than a few seconds.
+# @TEST-EXEC: bash %INPUT
+set -ux
+CWD=$(pwd)
+
+(mkdir .background && cd .background && btest-bg-run zeek-http zeek 'exit_only_after_terminate=T' ${CWD}/http-server.js)
+
+zeek ./http-client.js exit_only_after_terminate=T >&2
+res=$?
+
+(cd .background && btest-bg-wait 1)
+
+exit $res
+
+@TEST-START-FILE http-server.js
+const http = require('http');
+
+var counter = 0;
+
+const server = http.createServer((req, resp) => {
+  ++counter;
+  resp.end(`${counter}\n`);
+});
+
+server.listen(3000);
+@TEST-END-FILE
+
+@TEST-START-FILE http-client.js
+const http = require('http');
+
+var counter = 1;
+
+const url = new URL('http://localhost:3000');
+
+const makeRequest = () => {
+  console.log(`making request - ${counter}`);
+  const req = http.request(url, (res) => {
+    console.log(`Got response: ${res.statusCode}`);
+    res.on('data', (chunk) => {
+      chunk = chunk.toString().trim();
+      const n = parseInt(chunk);
+      console.log(`chunk=${chunk} n=${n} counter=${counter}`);
+      ++counter;
+      if (counter === 100) {
+        zeek.invoke('terminate');
+      }
+      setTimeout(makeRequest, 13);
+    });
+  });
+  req.on('error', (err) => {
+    console.error(`Request error: ${err}`);
+    process.exit(2);
+  });
+
+  req.end();
+};
+
+setTimeout(makeRequest, 13);
+setTimeout(() => {
+  console.error('Test did not finish in time - exit 1');
+  process.exit(1);
+}, 5000);
+
+@TEST-END-FILE


### PR DESCRIPTION
TCP handles are not added to the IO loop until a second call to
uv__io_poll(). Collect the uv_handles with a file descriptor and
if they changed, ensure we call uv_run() again by doing it once
more, or on the next IO loop iteration.

Add a test that does 100 HTTP requests via two zeek instances.
