### PR TITLE
zeek.on/zeek.hook: Switch from bare priority to options object

### DIFF
--- a/doc/examples/log-bypass.js
+++ b/doc/examples/log-bypass.js
@@ -6,7 +6,7 @@ BigInt.prototype.toJSON = function() {
   return this.toString();
 }
 
-zeek.hook('Log::log_stream_policy', -1000, function(rec, log_id) {
+zeek.hook('Log::log_stream_policy', {priority: -1000}, function(rec, log_id) {
   // Conn::Info to Conn, PacketFilter::Info to PacketFilter
   if (log_id.includes('::'))
     [log_id] = log_id.split('::')

--- a/doc/zeek.js
+++ b/doc/zeek.js
@@ -8,7 +8,7 @@
  * Register a function as a Zeek event handler.
  *
  * @param {string} name - The Zeek event name. For example, zeek_init.
- * @param {number} [priority=0] - Optional priority.
+ * @param {object} [options] - Optional options. Only supported key is priority.
  * @param {function} handler - The function to call.
  *
  */
@@ -21,7 +21,7 @@ exports.on = function() { }
  * in a Zeek hook handler.
  *
  * @param {string} name - The name of the hook. For example, ``DNS::log_policy``.
- * @param {number} [priority=0] - Optional priority.
+ * @param {object} [options] - Optional options. Only supported key is priority.
  * @param {function} handler - The function to call.
  *
  */

--- a/tests/zeekjs/cluster-node.sh
+++ b/tests/zeekjs/cluster-node.sh
@@ -7,7 +7,7 @@ zeek.on('zeek_init', function() {
   console.log(`Hey, I am ${zeek.global_vars['Cluster::node']}`);
   console.log(`Cluster::nodes=${JSON.stringify(zeek.global_vars['Cluster::nodes'])}`);
 });
-zeek.on('zeek_init', -10, function() {
+zeek.on('zeek_init', { priority: -10 }, function() {
   zeek.invoke('terminate');
 });
 @TEST-END-FILE

--- a/tests/zeekjs/hook-load-file.js
+++ b/tests/zeekjs/hook-load-file.js
@@ -38,13 +38,13 @@ event zeek_init() &priority=-5 {
 @TEST-END-FILE
 
 @TEST-START-FILE .js
-zeek.on('zeek_init', -6, function() {
+zeek.on('zeek_init', { priority: -6 }, function() {
   zeek.print('PASS: .js was loaded as Javascript file.');
 });
 @TEST-END-FILE
 
 @TEST-START-FILE a.js
-zeek.on('zeek_init', -7, function() {
+zeek.on('zeek_init', { priority: -7 }, function() {
   zeek.print('PASS: a.js was loaded as Javascript file.');
 });
 @TEST-END-FILE

--- a/tests/zeekjs/hook/no-break.sh
+++ b/tests/zeekjs/hook/no-break.sh
@@ -12,7 +12,7 @@ BigInt.prototype.toJSON = function() {
   return parseInt(this);
 }
 
-zeek.hook('Log::log_stream_policy', -1000, function(rec, id) {
+zeek.hook('Log::log_stream_policy', { priority: -1000 }, function(rec, id) {
 
   // Skip packet_filter, it is not using network time.
   if (id.startsWith("PacketFilter"))

--- a/tests/zeekjs/hook/priority.sh
+++ b/tests/zeekjs/hook/priority.sh
@@ -3,8 +3,8 @@
 # @TEST-EXEC: btest-diff .stdout
 
 @TEST-START-FILE priority.js
-zeek.hook('DNS::log_policy', -10, () => { zeek.print('[JS] DNS::log_policy: -10'); })
-zeek.hook('DNS::log_policy', 10, () => { zeek.print('[JS] DNS::log_policy: 10'); })
+zeek.hook('DNS::log_policy', { priority: -10 }, () => { zeek.print('[JS] DNS::log_policy: -10'); })
+zeek.hook('DNS::log_policy', { priority: 10 }, () => { zeek.print('[JS] DNS::log_policy: 10'); })
 @TEST-END-FILE
 
 

--- a/tests/zeekjs/hook/with-break.sh
+++ b/tests/zeekjs/hook/with-break.sh
@@ -13,7 +13,7 @@ BigInt.prototype.toJSON = function() {
   return parseInt(this);
 }
 
-zeek.hook('Log::log_stream_policy', -1000, function(rec, id) {
+zeek.hook('Log::log_stream_policy', { priority: -1000 }, function(rec, id) {
 
   // Skip packet_filter, it is not using network time.
   if (id.startsWith("PacketFilter"))

--- a/tests/zeekjs/priority.sh
+++ b/tests/zeekjs/priority.sh
@@ -3,15 +3,15 @@
 # @TEST-EXEC: btest-diff .stdout
 
 @TEST-START-FILE priority.js
-zeek.on('zeek_init', -10, () => { zeek.print('[JS] zeek_init: -10'); })
-zeek.on('zeek_init', 10, () => { zeek.print('[JS] zeek_init: 10'); })
+zeek.on('zeek_init', { priority: -10 }, () => { zeek.print('[JS] zeek_init: -10'); })
+zeek.on('zeek_init', {priority: 10 }, () => { zeek.print('[JS] zeek_init: 10'); })
 zeek.on('zeek_init', () => { zeek.print('[JS] zeek_init: 0 (default)'); })
 
 zeek.on('dns_request', function(c, msg, query, qtype, qclass) {
   zeek.print(`[JS] dns_request: 0 (default) ${query}`);
 });
 
-zeek.on('dns_request', 10, function(c, msg, query, qtype, qclass) {
+zeek.on('dns_request', { priority: 10 }, function(c, msg, query, qtype, qclass) {
   zeek.print(`[JS] dns_request: 10 ${query}`);
 });
 @TEST-END-FILE


### PR DESCRIPTION
Rather than a bare number as an optional "middle argument", make it
an options object for future extensibility.

    zeek.on("zeek_init", { priority: 10 }, () => { console.log('Hello World'); });