### PR TITLE
tests: Skip log-events.sh / new-event.sh test on older releases witho…

### DIFF
--- a/tests/Baseline/zeekjs.log-events/.stdout
+++ b/tests/Baseline/zeekjs.log-events/.stdout
@@ -63,6 +63,7 @@ SSL::log_ssl: {
   "server_name": "corelight.com",
   "resumed": false,
   "established": true,
+  "ssl_history": "CsiI"
 }
 Conn::log_conn: {
   "ts": 1630238733.951343,

--- a/tests/Baseline/zeekjs.new-event/.stdout
+++ b/tests/Baseline/zeekjs.new-event/.stdout
@@ -2865,6 +2865,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -2938,6 +2939,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3011,6 +3013,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3084,6 +3087,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3157,6 +3161,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3230,6 +3235,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3303,6 +3309,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3376,6 +3383,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3449,6 +3457,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3522,6 +3531,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3595,6 +3605,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3668,6 +3679,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3741,6 +3753,7 @@ ssl_extension [
         "client_psk_seen": false,
         "established": false,
         "logged": false,
+        "ssl_history": "",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3818,6 +3831,7 @@ ssl_plaintext_data [
         "analyzer_id": 13,
         "established": false,
         "logged": false,
+        "ssl_history": "C",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3901,6 +3915,7 @@ ssl_extension [
         "analyzer_id": 13,
         "established": false,
         "logged": false,
+        "ssl_history": "C",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -3981,6 +3996,7 @@ ssl_extension [
         "analyzer_id": 13,
         "established": false,
         "logged": false,
+        "ssl_history": "C",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -4062,6 +4078,7 @@ ssl_plaintext_data [
         "analyzer_id": 13,
         "established": false,
         "logged": false,
+        "ssl_history": "Cs",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -4148,6 +4165,7 @@ ssl_plaintext_data [
         "analyzer_id": 13,
         "established": false,
         "logged": false,
+        "ssl_history": "Csi",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -4234,6 +4252,7 @@ ssl_plaintext_data [
         "analyzer_id": 13,
         "established": false,
         "logged": false,
+        "ssl_history": "CsiI",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -4320,6 +4339,7 @@ ssl_established [
         "analyzer_id": 13,
         "established": false,
         "logged": false,
+        "ssl_history": "CsiI",
         "server_depth": 0,
         "client_depth": 0
       }
@@ -4427,6 +4447,7 @@ connection_state_remove [
         "client_psk_seen": false,
         "established": true,
         "logged": true,
+        "ssl_history": "CsiI",
         "server_depth": 0,
         "client_depth": 0
       }

--- a/tests/zeekjs/log-events.sh
+++ b/tests/zeekjs/log-events.sh
@@ -1,8 +1,9 @@
 # @TEST-DOC: Basic testing of the common log_ events from the base scripts
+# Only run this tests if ssl_history exists to keep a single baseline.
+# @TEST-REQUIRES: zeek -e 'exit(|get_record_field_comments("SSL::Info$ssl_history")| > 0 ? 0 : 1)'
 # @TEST-EXEC: zeek -r $TRACES/dns-http-https.pcap ./log-events.js
 # SSL history does not exist with Zeek 4
-# @TEST-EXEC: grep -v ssl_history .stdout > stdout.no_ssl_history
-# @TEST-EXEC: btest-diff stdout.no_ssl_history
+# @TEST-EXEC: btest-diff .stdout
 
 @TEST-START-FILE log-events.js
 // Interpret BigInt as simple number - do not use this unless

--- a/tests/zeekjs/new-event.sh
+++ b/tests/zeekjs/new-event.sh
@@ -1,8 +1,8 @@
 # @TEST-DOC: Hook into new_event and record the output. Might require baseline frequent baseline updates.
+# Only run this tests if ssl_history exists to keep a single baseline.
+# @TEST-REQUIRES: zeek -e 'exit(|get_record_field_comments("SSL::Info$ssl_history")| > 0 ? 0 : 1)'
 # @TEST-EXEC: zeek -r $TRACES/dns-http-https.pcap ./new-event.js
-# SSL history does not exist with Zeek 4
-# @TEST-EXEC: grep -v ssl_history .stdout > stdout.no_ssl_history
-# @TEST-EXEC: btest-diff stdout.no_ssl_history
+# @TEST-EXEC: btest-diff .stdout
 
 @TEST-START-FILE new-event.js
 // Interpret BigInt as simple number - do not use this unless


### PR DESCRIPTION
…ut SSL::Info::ssl_history

Mostly to simplify dealing with baselines.