### PR TITLE
Fixing how libnode is found & Remove some CAF references

### DIFF
--- a/cmake/FindNodejs.cmake
+++ b/cmake/FindNodejs.cmake
@@ -2,17 +2,16 @@
 #
 # Usage of this module as follows:
 #
-#     find_package(Nodejs)
+# find_package(Nodejs)
 #
 # Variables used by this module, they can change the default behaviour and
 # need to be set before calling find_package:
 #
-#  NODEJS_ROOT_DIR   Set this variable to the root installation of
-#                    Node.js if the module has problems finding
-#                    the proper installation path.
+# NODEJS_ROOT_DIR   Set this variable to the root installation of
+# Node.js if the module has problems finding
+# the proper installation path.
 #
 include(FindPackageHandleStandardArgs)
-
 
 find_path(NODEJS_INCLUDE_DIR
     NAMES node/node.h
@@ -53,22 +52,18 @@ find_path(V8_CONFIG_INCLUDE_DIR
 # libnode.so.111, node 19.0.0
 #
 set(nodejs_known_names
-    "node"
-    "libnode.so"
-    "libnode.so.83"
-    "libnode.so.93"
-    "libnode.so.102"
-    "libnode.so.108"
-    "libnode.so.111"
+    "libnode.so" "libnode.dylib"
+    "libnode.so.83" "libnode.83.dylib"
+    "libnode.so.93" "libnode.93.dylib"
+    "libnode.so.102" "libnode.102.dylib"
+    "libnode.so.108" "libnode.108.dylib"
+    "libnode.so.111" "libnode.111.dylib"
 )
 
 find_library(NODEJS_LIBRARY
     NAMES ${nodejs_known_names}
     PATHS ${NODEJS_ROOT_DIR}/lib
     NO_DEFAULT_PATH
-)
-find_library(NODEJS_LIBRARY
-    NAMES ${nodejs_known_names}
 )
 
 find_package_handle_standard_args(Nodejs DEFAULT_MSG

--- a/cmake/FindNodejs.cmake
+++ b/cmake/FindNodejs.cmake
@@ -2,16 +2,17 @@
 #
 # Usage of this module as follows:
 #
-# find_package(Nodejs)
+#     find_package(Nodejs)
 #
 # Variables used by this module, they can change the default behaviour and
 # need to be set before calling find_package:
 #
-# NODEJS_ROOT_DIR   Set this variable to the root installation of
-# Node.js if the module has problems finding
-# the proper installation path.
+#  NODEJS_ROOT_DIR   Set this variable to the root installation of
+#                    Node.js if the module has problems finding
+#                    the proper installation path.
 #
 include(FindPackageHandleStandardArgs)
+
 
 find_path(NODEJS_INCLUDE_DIR
     NAMES node/node.h
@@ -64,6 +65,9 @@ find_library(NODEJS_LIBRARY
     NAMES ${nodejs_known_names}
     PATHS ${NODEJS_ROOT_DIR}/lib
     NO_DEFAULT_PATH
+)
+find_library(NODEJS_LIBRARY
+    NAMES ${nodejs_known_names}
 )
 
 find_package_handle_standard_args(Nodejs DEFAULT_MSG

--- a/configure
+++ b/configure
@@ -25,7 +25,6 @@ Usage: $0 [OPTIONS]
     --install-root=DIR         Path where to install plugin into
     --with-binpac=DIR          Path to BinPAC installation root
     --with-broker=DIR          Path to Broker installation root
-    --with-caf=DIR             Path to CAF installation root
     --with-bifcl=PATH          Path to bifcl executable
     --enable-debug             Compile in debugging mode
 EOF
@@ -85,11 +84,6 @@ while [ $# -ne 0 ]; do
         --with-broker=*)
             append_cache_entry BROKER_ROOT_DIR PATH $optarg
             broker_root=$optarg
-            ;;
-
-        --with-caf=*)
-            append_cache_entry CAF_ROOT_DIR PATH $optarg
-            caf_root=$optarg
             ;;
 
         --with-bifcl=*)
@@ -153,10 +147,6 @@ if [ -z "$zeekdist" ]; then
 
     if [ -z "$broker_root" ]; then
         append_cache_entry BROKER_ROOT_DIR PATH `${zeek_config} --broker_root`
-    fi
-
-    if [ -z "$caf_root" ]; then
-        append_cache_entry CAF_ROOT_DIR PATH `${zeek_config} --caf_root`
     fi
 else
     if [ ! -e "$zeekdist/zeek-path-dev.in" ]; then


### PR DESCRIPTION
This still feels like it's being done wrong, but it at least gets us to build parity on Mac OS.

This also includes some minor changes to stop looking for CAF since that's not necessary anymore and zeekjs doesn't used broker/caf anyway.