### PR TITLE
Use PLUGIN_DBG_LOG for dprintf()

### DIFF
--- a/src/IOLoop.cc
+++ b/src/IOLoop.cc
@@ -42,9 +42,9 @@ PipeSource::PipeSource(plugin::Nodejs::Instance* instance) : instance_(instance)
 
 PipeSource::~PipeSource() {
   if (close(notify_pipe_[0]) != 0)
-    eprintf("Failed to close _notify_pipe[0]");
+    eprintf("%s", "Failed to close _notify_pipe[0]");
   if (close(notify_pipe_[1]) != 0)
-    eprintf("Failed to close _notify_pipe[0]");
+    eprintf("%s", "Failed to close _notify_pipe[0]");
 }
 
 void PipeSource::Process() {

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -231,7 +231,7 @@ class InvokeJsEventHandlerStmt : public zeek::detail::Stmt {
 
 #ifdef ZEEKJS_STMT_NEEDS_DUPLICATE
   zeek::detail::StmtPtr Duplicate() override {
-    eprintf("XXX: This will likely blow up");
+    eprintf("%s", "XXX: This will likely blow up");
     return {zeek::NewRef{}, this};
   }
 #endif
@@ -267,7 +267,7 @@ class InvokeJsHookHandlerStmt : public zeek::detail::Stmt {
 
 #ifdef ZEEKJS_STMT_NEEDS_DUPLICATE
   zeek::detail::StmtPtr Duplicate() override {
-    eprintf("XXX: This will likely blow up");
+    eprintf("%s", "XXX: This will likely blow up");
     return {zeek::NewRef{}, this};
   }
 #endif

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -11,7 +11,6 @@
 
 #include "IOLoop.h"
 #include "Nodejs.h"
-#include "ZeekJS.h"
 
 namespace plugin::Corelight_ZeekJS {
 

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -1,7 +1,6 @@
 #include "Types.h"
 
 #include "ZeekCompat.h"
-#include "ZeekJS.h"
 
 #include "zeek/IPAddr.h"
 #include "zeek/IntrusivePtr.h"
@@ -9,6 +8,8 @@
 #include "zeek/Val.h"
 #include "zeek/ZeekString.h"
 #include "zeek/module_util.h"
+
+#include "Plugin.h"
 
 namespace {
 
@@ -880,7 +881,7 @@ void ZeekValWrapper::ZeekTableGetter(v8::Local<v8::Name> property,
   v8::String::Utf8Value arg(isolate, property);
 
   if (!*arg) {
-    dprintf("empty arg?");
+    dprintf("%s", "empty arg?");
     return;
   }
 

--- a/src/ZeekJS.h
+++ b/src/ZeekJS.h
@@ -1,12 +1,9 @@
 #pragma once
-#include <chrono>
-using std::chrono::duration_cast;
-using std::chrono::microseconds;
-using std::chrono::seconds;
-using std::chrono::system_clock;
 
+#include <zeek/DebugLogger.h>
 #include <zeek/Event.h>
 #include <zeek/Stmt.h>
+#include <zeek/plugin/Plugin.h>
 
 namespace plugin::Corelight_ZeekJS::Js {
 
@@ -31,28 +28,20 @@ class HookHandler {
 };
 
 /* Poor man's logging */
-#define eprintf(...)                                        \
-  do {                                                      \
-    auto __now = system_clock::now().time_since_epoch();    \
-    auto __us = duration_cast<microseconds>(__now).count(); \
-    std::fprintf(stderr, "[ ERROR ] %s: ", __func__);       \
-    std::fprintf(stderr, __VA_ARGS__);                      \
-    std::fprintf(stderr, "\n");                             \
+#define eprintf(fmt, ...)                             \
+  do {                                                \
+    std::fprintf(stderr, "[ ERROR ] %s: ", __func__); \
+    std::fprintf(stderr, fmt, __VA_ARGS__);           \
+    std::fprintf(stderr, "\n");                       \
   } while (0);
 
-// #define DEBUG 1
 #ifdef DEBUG
-#define dprintf(...)                                                       \
-  do {                                                                     \
-    auto __now = system_clock::now().time_since_epoch();                   \
-    auto __us = duration_cast<microseconds>(__now).count();                \
-    std::fprintf(stderr, "%lf [ DEBUG ] %s ", __us / 1000000.0, __func__); \
-    std::fprintf(stderr, __VA_ARGS__);                                     \
-    std::fprintf(stderr, "\n");                                            \
+#define dprintf(fmt, ...)                                                    \
+  do {                                                                       \
+    PLUGIN_DBG_LOG(::plugin::Corelight_ZeekJS::plugin, "%s: " fmt, __func__, \
+                   __VA_ARGS__);                                             \
   } while (0);
 #else
-#define dprintf(...) \
-  do {               \
-  } while (0);
+#define dprintf(fmt, ...)
 #endif
 }  // namespace plugin::Corelight_ZeekJS::Js


### PR DESCRIPTION
Previously everything was simply logged to stderr, but that was pretty annoying when using debug builds. Switch to the usual way of logging though the debug streams.

Debug messages can be enabled as follows now:

    ZEEK_DEBUG_LOG_STDERR=1 zeek -B plugin-Zeek-JavaScript ./examples/hello.js