### PR TITLE
Re-add Zeek nightly build, remove CMakeLists.txt zeekdeps wrangling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         distro:
           - ubuntu-2210
           - fedora-37
-            # - fedora-37-nightly
+          - fedora-37-nightly
           - debian-bookworm
           - debian-bookworm-lts
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,7 @@ include_directories(BEFORE ${NODEJS_INCLUDE_DIR} ${UV_INCLUDE_DIR} ${V8_CONFIG_I
 
 zeek_plugin_begin(Zeek JavaScript)
 
-if ( ZEEK_PLUGIN_INTERNAL_BUILD )
-    # This is a hack for the current bug in zeek with doing built in plugins
-    set(zeekdeps ${zeekdeps} ${NODEJS_LIBRARIES} PARENT_SCOPE)
-else()
-    zeek_plugin_link_library("${NODEJS_LIBRARIES}")
-endif()
+zeek_plugin_link_library("${NODEJS_LIBRARIES}")
 
 #
 # Observed the following errors on Debian with GCC 8.3.0:


### PR DESCRIPTION
...the latter was added for Zeek being able to handel zeek_plugin_link_library() for included plugins properly. That time should have passed.