### PR TITLE
Avoid array bounds warning with GCC 13 in non-debug builds

### DIFF
--- a/src/Nodejs.cc
+++ b/src/Nodejs.cc
@@ -808,8 +808,8 @@ bool Instance::Init(plugin::Corelight_ZeekJS::Plugin* plugin,
   // callback corrupts the async stack and setting this flag
   // prevents node exiting due to this.
   if (!exit_on_uncaught_exceptions) {
-    args.emplace_back("--no-force-async-hooks-checks");
-    args.emplace_back("--trace-uncaught");
+    args.push_back("--no-force-async-hooks-checks");  // NOLINT
+    args.push_back("--trace-uncaught");               // NOLINT
   }
 
 #if NODE_VERSION_AT_LEAST(18, 11, 0)


### PR DESCRIPTION
This seems pretty silly but this is currently triggering the biggest block of warnings in my local Zeek release builds, see attached [warnings.txt](https://github.com/corelight/zeekjs/files/11777491/warnings.txt). CI example [here](https://cirrus-ci.com/task/6129304585633792?logs=build#L1659-L1799).