### PR TITLE
Nodejs: Unset kNoInitializeCppgc for Node 20.6 or higher

### DIFF
--- a/src/Nodejs.cc
+++ b/src/Nodejs.cc
@@ -814,6 +814,12 @@ bool Instance::Init(plugin::Corelight_ZeekJS::Plugin* plugin,
 
 #if NODE_VERSION_AT_LEAST(18, 11, 0)
   auto flags = node::ProcessInitializationFlags::kLegacyInitializeNodeWithArgsBehavior;
+#if NODE_VERSION_AT_LEAST(20, 6, 0)
+  // Let Node.js initialize the Oilpan cppgc garbage collector.
+  flags = node::ProcessInitializationFlags::Flags(
+      flags & (~node::ProcessInitializationFlags::kNoInitializeCppgc));
+#endif
+
   auto result = node::InitializeOncePerProcess(args, flags);
   int r = result->exit_code();
 #else


### PR DESCRIPTION
kLegacyInitializeNodeWithArgsBehavior does not contain the flag to initialize the new cppgc garbage collector which means the embedder is required to initialize and shutdown cppgc. Unset the flag so Node does it for us.

Found by @simeonmiteff , thanks!