### PR TITLE
ci: Use Zeek 6.1 on Fedora

### DIFF
--- a/docker/fedora-37.Dockerfile
+++ b/docker/fedora-37.Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install -y \
 
 RUN dnf config-manager --add-repo https://download.opensuse.org/repositories/security:zeek/Fedora_37/security:zeek.repo
 
-ENV ZEEK_VERSION='6.0.*'
+ENV ZEEK_VERSION='6.1.*'
 
 RUN dnf install -y \
   zeek-btest-$ZEEK_VERSION \

--- a/docker/fedora-38.Dockerfile
+++ b/docker/fedora-38.Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install -y \
 
 RUN dnf config-manager --add-repo https://download.opensuse.org/repositories/security:zeek/Fedora_37/security:zeek.repo
 
-ENV ZEEK_VERSION='6.0.*'
+ENV ZEEK_VERSION='6.1.*'
 
 RUN dnf install -y \
   zeek-btest-$ZEEK_VERSION \


### PR DESCRIPTION
Unfortunately, once 6.1 was released, the zeek 6.0 packages ceased to exist.