### PR TITLE
Types: Cast internal field to v8::Value

### DIFF
--- a/cmake/FindNodejs.cmake
+++ b/cmake/FindNodejs.cmake
@@ -49,12 +49,6 @@ find_path(V8_CONFIG_INCLUDE_DIR
     NAMES v8config.h
 )
 
-#
-# libnode.so.83, Fedora 34, node 14.18
-# libnode.so.93, Fedora 35, node 16.13
-# libnode.so.102, node 17.3.0
-# libnode.so.111, node 19.0.0
-#
 set(nodejs_known_names
     "libnode.so" "libnode.dylib"
     "libnode.so.83" "libnode.83.dylib"
@@ -63,6 +57,7 @@ set(nodejs_known_names
     "libnode.so.108" "libnode.108.dylib"
     "libnode.so.111" "libnode.111.dylib"
     "libnode.so.115" "libnode.115.dylib"
+    "libnode.so.120" "libnode.120.dylib"
 )
 
 if ( NODEJS_ROOT_DIR )

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -141,7 +141,7 @@ ZeekValWrapper::ZeekValWrapper(v8::Isolate* isolate) : isolate_(isolate) {
   v8::FunctionCallback toJSON_callback =
       [](const v8::FunctionCallbackInfo<v8::Value>& info) -> void {
     v8::Local<v8::Object> receiver = info.This();
-    info.GetReturnValue().Set(receiver->GetInternalField(0));
+    info.GetReturnValue().Set(receiver->GetInternalField(0).As<v8::Value>());
   };
 
   port_toJSON_function_.Reset(
@@ -154,7 +154,7 @@ ZeekValWrapper::ZeekValWrapper(v8::Isolate* isolate) : isolate_(isolate) {
   v8::AccessorGetterCallback toJSON_cb =
       [](v8::Local<v8::String> property,
          const v8::PropertyCallbackInfo<v8::Value>& info) {
-        info.GetReturnValue().Set(info.This()->GetInternalField(2));
+        info.GetReturnValue().Set(info.This()->GetInternalField(2).As<v8::Value>());
       };
 
   port_template->SetAccessor(v8_str_intern("toJSON"), toJSON_cb, nullptr,
@@ -166,7 +166,7 @@ ZeekValWrapper::ZeekValWrapper(v8::Isolate* isolate) : isolate_(isolate) {
   v8::AccessorGetterCallback port_cb =
       [](v8::Local<v8::String> property,
          const v8::PropertyCallbackInfo<v8::Value>& info) {
-        info.GetReturnValue().Set(info.This()->GetInternalField(0));
+        info.GetReturnValue().Set(info.This()->GetInternalField(0).As<v8::Value>());
       };
   port_template->SetAccessor(v8_str_intern("port"), port_cb, nullptr,
                              v8::Local<v8::Value>(), v8::AccessControl::DEFAULT,
@@ -177,7 +177,7 @@ ZeekValWrapper::ZeekValWrapper(v8::Isolate* isolate) : isolate_(isolate) {
       [](v8::Local<v8::String> property,
          const v8::PropertyCallbackInfo<v8::Value>& info) {
         info.GetIsolate();
-        info.GetReturnValue().Set(info.This()->GetInternalField(1));
+        info.GetReturnValue().Set(info.This()->GetInternalField(1).As<v8::Value>());
       };
   port_template->SetAccessor(v8_str_intern("proto"), proto_cb, nullptr,
                              v8::Local<v8::Value>(), v8::AccessControl::DEFAULT,


### PR DESCRIPTION
With Node 21.2 and its V8 version a static assertion triggers because ReturnValue::Set() expects a v8::Value, but GetInternalField() returns v8::Data.

Similar to: https://github.com/nodejs/node/commit/6c389df3aa

---

```
In file included from /opt/node-21.2.0/include/node/v8-function.h:11,
                 from /opt/node-21.2.0/include/node/v8.h:33,
                 from /opt/node-21.2.0/include/node/node.h:73,
                 from /home/awelzel/corelight-oss/zeek/auxil/zeekjs/src/Nodejs.h:6,
                 from /home/awelzel/corelight-oss/zeek/auxil/zeekjs/src/Plugin.h:13,
                 from /home/awelzel/corelight-oss/zeek/auxil/zeekjs/src/Types.cc:3:
/opt/node-21.2.0/include/node/v8-function-callback.h: In instantiation of ‘void v8::ReturnValue<F>::Set(v8::Local<S>) [with S = v8::Data; T = v8::Value]’:
/home/awelzel/corelight-oss/zeek/auxil/zeekjs/src/Types.cc:144:30:   required from here
/opt/node-21.2.0/include/node/v8-function-callback.h:304:40: error: static assertion failed: type check
  304 |   static_assert(std::is_void<T>::value || std::is_base_of<T, S>::value,
      |                                  ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/node-21.2.0/include/node/v8-function-callback.h:304:40: note: ‘(((bool)std::integral_constant<bool, false>::value) || ((bool)std::integral_constant<bool, false>::value))’ evaluates to false
ninja: build stopped: subcommand failed.
```