### PR TITLE
Update docs to provide example of shared Node.js openSSL configuration

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,8 +65,13 @@ and install it.
 
     $ git clone https://github.com/nodejs/node.git
     $ cd node
+
+    # Reset repo to a specific Node.js version
     $ git reset --hard v19.9.0
-    $ ./configure --prefix=/opt/node-19 --shared
+
+    # Configure Node.js with shared OpenSSL and set desired installation prefix
+    $ ./configure --prefix=/opt/node-19 --shared-openssl
+
     $ make
     $ sudo make install
 


### PR DESCRIPTION
A segfault discussed on the Zeek slack forum occurs when Zeek and Node.js do not have aligned versions of openSSL. Updating docs to reflect the fix proposed. 