### PR TITLE
Plugin: Reset stack limit at draining time

### DIFF
--- a/scripts/__load__.zeek
+++ b/scripts/__load__.zeek
@@ -52,6 +52,9 @@ export {
 	const maximum_heap_size_in_bytes: count = 128 * 1024 * 1024 &redef;
 	const thread_pool_size: count = 4 &redef;
 
+	## JavaScript V8's default 64bit stack size is 984 KB.
+	const stack_size: count = 984 * 1024 &redef;
+
 	## Node.js default behavior is to exit a process on uncaught exceptions.
 	## Specifically exceptions in timer callbacks are problematic as a throwing
 	## timer callback may break subsequently scheduled timers.

--- a/src/Nodejs.h
+++ b/src/Nodejs.h
@@ -26,8 +26,9 @@ struct InitOptions {
   std::vector<std::filesystem::path> files;
   size_t initial_heap_size_in_bytes = 67108864;   // 64 MB
   size_t maximum_heap_size_in_bytes = 134217728;  // 128 MB
-  bool exit_on_uncaught_exceptions = true;
   int thread_pool_size = 4;
+  size_t stack_size = 1007616;  // 984 KB
+  bool exit_on_uncaught_exceptions = true;
   bool owns_process_state = false;
   bool owns_node_inspector = false;
 };
@@ -53,6 +54,9 @@ class Instance {
 
   void SetJsCalled(bool js_called = true) { js_called_ = js_called; };
   bool WasJsCalled() { return js_called_; };
+
+  // Update the stack limit used by V8's isolate.
+  void SetStackLimit();
 
   //
   // Invoked from Javascript to register the given function as
@@ -151,6 +155,9 @@ class Instance {
 
   // Marker for HookDrainEvents() whether instance->Process() should be called.
   bool js_called_ = false;
+
+  // Stack size to configure the isolate before processing events.
+  size_t stack_size_ = 1007616;  // 984 KB
 
   // Handle to the Node.js "process" object. Used for top-level CallbackScope
   // invocations. This is the object that Node.js uses for CheckImmediate and


### PR DESCRIPTION
Spicy is using alternative stacks to execute fibres and may drain
and execute events on these alternative stacks. E.g., this happens
during DataIn() and subsequent GetFileID() calls.
This confuses V8's own stack limit checking, reporting that the call
stack was exceeded.

Reset the stack limit whenever events are drained, or the IO sources
Process() method is called.

This was triggered when implementing file_state_remove() with the
spicy-zip analyzer enabled and analyzing a ZIP file.
