### PR TITLE
Instance: Offload JavaScript invocations to executor thread

### DIFF
--- a/docker/fedora-41-nightly.Dockerfile
+++ b/docker/fedora-41-nightly.Dockerfile
@@ -1,5 +1,8 @@
 FROM fedora:41
 
+# Bust the cache
+ARG STAMP=1741531139
+
 # Dependencies required to compile and test ZeekJS on Fedora
 RUN dnf install -y \
   cmake \
@@ -10,10 +13,11 @@ RUN dnf install -y \
   which \
   clang-tools-extra
 
-# Bust the cache
-ARG STAMP=1729535688
+# Ensure the sqlite-libs package is available to avoid:
+# $ node --version
+# node: symbol lookup error: /lib64/libnode.so.127: undefined symbol: sqlite3session_attach
+RUN dnf update -y sqlite-libs
 
-# Use Fedora 40 packages until Fedora 41 is supported.
 RUN dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/security:zeek/Fedora_41/security:zeek.repo
 
 RUN dnf install -y \

--- a/docker/fedora-41.Dockerfile
+++ b/docker/fedora-41.Dockerfile
@@ -1,5 +1,8 @@
 FROM fedora:41
 
+# Bust the cache
+ARG STAMP=1741531092
+
 # Dependencies required to compile and test ZeekJS on Fedora
 RUN dnf install -y \
   cmake \
@@ -10,10 +13,11 @@ RUN dnf install -y \
   which \
   clang-tools-extra
 
-# Bust the cache
-ARG STAMP=1729535688
+# Ensure the sqlite-libs package is available to avoid:
+# $ node --version
+# node: symbol lookup error: /lib64/libnode.so.127: undefined symbol: sqlite3session_attach
+RUN dnf update -y sqlite-libs
 
-# Use Fedora 40 packages until Fedora 41 is supported.
 RUN dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/security:zeek/Fedora_41/security:zeek.repo
 
 RUN dnf install -y \

--- a/src/Executor.h
+++ b/src/Executor.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace plugin::Nodejs {
+
+/**
+ * Helper class to offload execution of function to a separate thread.
+ */
+class Executor {
+ public:
+  Executor() : t(std::thread([this] { Loop(); })) {}
+  ~Executor() {
+    {
+      std::unique_lock lk{mtx};
+      stop = true;
+      cv.notify_one();
+    }
+
+    try {
+      t.join();
+      // NOLINTNEXTLINE(bugprone-empty-catch)
+    } catch (...) {
+      // swallow
+    }
+  }
+
+  /**
+   * Runs the given function and arguments in the thread
+   * started by this executor and waits for the result.
+   */
+  template <typename Func, typename... Args>
+  auto Run(Func f, Args&&... args) {
+    using ret_type = std::invoke_result_t<Func, Args...>;
+
+    // If Run() is invoked by the internal executor thread,
+    // just execute f(args...) directly, otherwise this
+    // results in a dead lock.
+    if (std::this_thread::get_id() == t.get_id()) {
+      return f(std::forward<Args>(args)...);
+    }
+
+    auto r = Submit(std::forward<Func>(f), std::forward<Args>(args)...);
+
+    r.wait();
+
+    if constexpr (std::is_same_v<ret_type, void>) {
+      return;
+    } else {
+      return r.get();
+    }
+  }
+
+ private:
+  /**
+   * Submit a function its arguments for execution by the executor,
+   * returning a future.
+   */
+  template <typename Func, typename... Args>
+  auto Submit(Func f, Args&&... args) {
+    using ret_type = std::invoke_result_t<Func, Args...>;
+
+    std::promise<ret_type> r;
+    auto result = r.get_future();
+
+    auto lc = std::packaged_task([r = std::move(r), f = std::move(f),
+                                  args =
+                                      std::make_tuple(std::move(args)...)]() mutable {
+      if constexpr (std::is_same_v<ret_type, void>) {
+        std::apply([f](auto&&... args) mutable { return f(args...); }, std::move(args));
+        r.set_value();
+      } else {
+        auto invoked =
+            std::apply([f](auto&&... args) { return f(args...); }, std::move(args));
+        r.set_value(invoked);
+      }
+    });
+
+    {
+      std::unique_lock lk{mtx};
+      queue.push(std::move(lc));
+      cv.notify_one();
+    }
+
+    return result;
+  }
+
+  /**
+   * Dequeue and execute the pending task.
+   */
+  void Loop() {
+    while (true) {
+      {
+        std::unique_lock lk{mtx};
+
+        while (queue.empty() && !stop)
+          cv.wait(lk);
+
+        while (!queue.empty()) {
+          queue.front()();  // run the task
+          queue.pop();      // consumes the task
+        }
+
+        if (stop)
+          break;
+      }
+    }
+  }
+
+  std::mutex mtx;  // Protects `queue` and `stop`.
+  bool stop = false;
+  std::condition_variable cv;
+  std::queue<std::packaged_task<void()>> queue;
+  std::thread t;  // Last member so ctr'd after all deps.
+};
+
+}  // namespace plugin::Nodejs

--- a/src/Nodejs.cc
+++ b/src/Nodejs.cc
@@ -586,7 +586,6 @@ struct HandlerArgs {
 
     result.name = v8::Local<v8::String>::Cast(args[0]);
 
-    int priority = 0;
     int func_idx = 0;
 
     if (args.Length() == 2) {
@@ -940,7 +939,6 @@ bool Instance::Init(plugin::Corelight_ZeekJS::Plugin* plugin,
 
     auto message_listener = [](v8::Local<v8::Message> message,
                                v8::Local<v8::Value> error) -> void {
-      v8::Isolate* isolate = message->GetIsolate();
       PrintUncaughtException(message, error);
     };
     isolate_->AddMessageListener(message_listener);

--- a/src/Nodejs.h
+++ b/src/Nodejs.h
@@ -8,6 +8,7 @@
 #include <node/v8.h>
 #include <uv.h>
 
+#include "Executor.h"
 #include "IOLoop.h"
 #include "Types.h"
 #include "ZeekJS.h"
@@ -37,7 +38,8 @@ class Instance {
  public:
   bool Init(plugin::Corelight_ZeekJS::Plugin* plugin, const InitOptions& options);
 
-  void BeforeExit();
+  void EmitProcessBeforeExit();
+  void EmitProcessExit();
   void Done();
 
   void SetZeekNotifier(plugin::Corelight_ZeekJS::IOLoop::PipeSource* n) {
@@ -47,6 +49,7 @@ class Instance {
   // Called by the thin JsLoopIOSource
   int GetLoopFd();
   void Process();
+  void ProcessLocked();
   void UpdateTime();
   double GetNextTimeout();
   bool IsAlive();
@@ -141,6 +144,8 @@ class Instance {
 
   v8::Isolate* isolate_;
 
+  v8::Persistent<v8::Context> context_;
+
   // Wrapping.
   std::unique_ptr<ZeekValWrapper> zeek_val_wrapper_;
 
@@ -156,6 +161,8 @@ class Instance {
   // invocations. This is the object that Node.js uses for CheckImmediate and
   // RunTimers, so lets do that, too.
   v8::Global<v8::Object> process_obj_;
+
+  Executor executor;
 };
 
 class EventHandler : public plugin::Corelight_ZeekJS::Js::EventHandler {

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -162,6 +162,11 @@ void Plugin::HookDrainEvents() {
   // and currently we're not processing a packet, run
   // Process() housekeeping now.
   if (nodejs->WasJsCalled()) {
+    // XXX: This call may not be needed anymore, it probably
+    //      papered over some previous shortcomings of how
+    //      JavaScript was invoked.
+    //
+    //      When commenting it out, all tests still succeed.
     nodejs->Process();
     nodejs->SetJsCalled(false);
   }
@@ -208,7 +213,7 @@ void Plugin::HookDrainEvents() {
   // Emit a beforeExit event that can be used by JavaScript to
   // schedule more work and keep the IO loop going.
   if (loop_io_source->IsOpen()) {
-    nodejs->BeforeExit();
+    nodejs->EmitProcessBeforeExit();
     if (nodejs->IsAlive()) {
       return;
     }


### PR DESCRIPTION
As discussed in https://github.com/zeek/zeek/issues/4239, sometimes the Zeek event queue is
drained with fiber stacks activated. This stack switching is not
something that V8 stack checking and garbage-collection is prepared
for. However, V8 has native support for threads. Offload JavaScript
execution to a dedicated thread to avoid executing V8 code from the
main thread on an alternative stack.

Fixes https://github.com/zeek/zeek/issues/4239