### PR TITLE
Avoid using `-fsanitize=vptr` when building Nodejs.cc with sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,14 @@ zeek_plugin_bif(src/zeekjs.bif)
 zeek_plugin_dist_files(README CHANGES COPYING VERSION)
 zeek_plugin_end()
 
+# Compiling Nodejs.cc with -fsanitize=vptr (e.g. as part of ubsan) can trigger
+# "undefined reference to `typeinfo for v8::ArrayBuffer::Allocator'". Suppress
+# vptr sanitization selectively for this file if any sanitizers are in effect.
+# See: https://groups.google.com/g/v8-users/c/MJztlKiWFUc/m/z3_V-SMvAwAJ
+if ("${CMAKE_CXX_FLAGS}" MATCHES "-fsanitize=")
+    set_source_files_properties(src/Nodejs.cc PROPERTIES COMPILE_FLAGS -fno-sanitize=vptr)
+endif ()
+
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" VERSION LIMIT_COUNT 1)
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")


### PR DESCRIPTION
Arne I was building Zeek with ubsan and JavaScript support and ran into:
```
[100%] Linking CXX executable src/zeek
/usr/bin/ld: src/builtin-plugins/zeekjs/CMakeFiles/plugin-Zeek-JavaScript.dir/src/Nodejs.cc.o:(.rodata._ZTIN4node20ArrayBufferAllocatorE[_ZTIN4node20ArrayBufferAllocatorE]+0x10): undefined reference to `typeinfo for v8::ArrayBuffer::Allocator'
collect2: error: ld returned 1 exit status
```
According to [this](https://groups.google.com/g/v8-users/c/MJztlKiWFUc/m/z3_V-SMvAwAJ), one ought to avoid `-fsanitize=vptr`, so I'm adding this here for Nodejs.cc when sanitizers are in use.