### PR TITLE
Remove use of Func::Name(), removed in 8.1

### DIFF
--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -363,13 +363,21 @@ bool Plugin::RegisterJsHookHandler(const std::string& name,
   }
   zeek::Func* func = id->GetVal()->AsFunc();
 
+#if ZEEK_VERSION_NUMBER < 80000
   dprintf("Have a func=%p %s priority=%d", func, func->Name(), priority);
+#else
+  dprintf("Have a func=%p %s priority=%d", func, func->GetName().c_str(), priority);
+#endif
 
   zeek::detail::StmtPtr stmt = zeek::make_intrusive<InvokeJsHookHandlerStmt>(js_hh);
   std::vector<zeek::detail::IDPtr> inits;  // ? What are inits?
   func->AddBody(stmt, inits, 0, priority);
 
+#if ZEEK_VERSION_NUMBER < 80000
   PLUGIN_DBG_LOG(plugin, "Added body to %s", func->Name());
+#else
+  PLUGIN_DBG_LOG(plugin, "Added body to %s", func->GetName().c_str());
+#endif
   return true;
 }
 


### PR DESCRIPTION
`Func::Name()` was deprecated in 8.0 and removed in 8.1, and so ZeekJS fails to build with the current 8.1-dev versions.