### PR TITLE
cmake: Fix quotation differences when matching through config.gypi

### DIFF
--- a/cmake/FindNodejs.cmake
+++ b/cmake/FindNodejs.cmake
@@ -92,7 +92,7 @@ if ( NODEJS_INCLUDE_DIR )
     # or node/config-<arch>.gypi.
     file(GLOB NODE_CONFIG_GYPIS "${NODEJS_INCLUDE_DIR}/node/config*gypi")
     foreach ( GYPI ${NODE_CONFIG_GYPIS} )
-        file(STRINGS "${GYPI}" HAVE_SHARED_LIB_UV REGEX "node_shared_libuv.*:.*'true'")
+        file(STRINGS "${GYPI}" HAVE_SHARED_LIB_UV REGEX "node_shared_libuv.*:.*true")
         if ( HAVE_SHARED_LIB_UV )
             find_package(LibUV REQUIRED)
             break ()


### PR DESCRIPTION
The .gypi file on my local system uses single quotes while in Zeek's CI on OSX double quotes are used and skipped finding libuv resulting in linker issues.

https://cirrus-ci.com/task/5256566288416768?logs=build#L3286