### PR TITLE
Fix link to Node embedding docs

### DIFF
--- a/scripts/__load__.zeek
+++ b/scripts/__load__.zeek
@@ -7,7 +7,7 @@ export {
 	## This comes fairly straight from the embedding guide to support using
 	## require() with filesystem paths in the process working directory.
 	##
-	## https://docs.w3cub.com/node~14_lts/embedding
+	## https://nodejs.org/api/embedding.html
 	##
 	const main_script_source: string = cat(
 		"const module_mod = require('module')\n",


### PR DESCRIPTION
The old link returned a 404.